### PR TITLE
Make callback optional

### DIFF
--- a/riggerlib/__init__.py
+++ b/riggerlib/__init__.py
@@ -651,15 +651,18 @@ class RiggerBasePlugin(object):
         inner.__wrapped__ = func
         return inner
 
-    def register_plugin_hook(self, event, callback, bg=False):
+    def register_plugin_hook(self, event, callback=None, bg=False):
         """
         Registers a plugins callback with the associated event. Each event can only have one
         plugin callback.
 
         For example, register_plugin_hook('start_test', self.start_test). The function will
         receive one parameter, and that will be the context variable which is passed from the
-        hook_fire.
+        hook_fire. Or you can omit the callback parameter, it will then infer the callback method
+        is called the same as the event.
         """
+        if callback is None:
+            callback = getattr(self, event)
         self.callbacks[event] = Rigger.create_callback(callback)
 
 


### PR DESCRIPTION
Since in most cases the name of the method corresponds with the event name, make it possible for RiggerBasePlugin to infer the method name from the event.