### PR TITLE
Fix no listener deadlock

### DIFF
--- a/riggerlib/task.py
+++ b/riggerlib/task.py
@@ -23,8 +23,10 @@ class Task():
 
     def __init__(self, json_dict):
         self.output = {}
-        self._tid = hashlib.sha1(str(time.time()) + json_dict['hook_name'] +
-                                 generate_random_string())
+        self._tid = hashlib.sha1("{}{}{}".format(
+            str(time.time()), json_dict['hook_name'],
+            generate_random_string().encode('ascii')).encode('ascii')
+        )
         self.json_dict = json_dict
         self.status = self.QUEUED
 


### PR DESCRIPTION
When the artifactor process finishes in the CFME integration tests, there is nothing listening on the tcp. But some logging related plugin in the CFME integration_tests is causing riggerlib trying to connect even after the artifactor process is stopped and it is sending a probe message. Thus the probe request is in the outgoing queue causing a hang in GC time when the Python is about to exit. ZMQ does not want to teardown the context of the socket in that case...

I was thinking about creating the tests, but as the deadlock happens on GC time when Python is doing cleanup on exit, I think I would have to spawn separate Python interpreter to get this tested.

I used this patch in PR https://github.com/ManageIQ/integration_tests/pull/9790 and so far I got 3 successive test runs with no deadlock.

Note this PR includes the d63174f (tagged v3.1.5) as it was necessary for its testing on Py3
